### PR TITLE
Update format to use bind parameters

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
+  "plugins": ["add-module-exports"],
   "presets": ["es2015-node4"]
 }

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,1 +1,4 @@
 extends: seegno
+
+rules:
+  id-match: off

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,1 +1,0 @@
-preset: seegno

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # sql-tag
 
-A template tag for writing elegant sql strings based on [ES6 tagged template strings](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/template_strings#Tagged_template_strings).
+A template tag for writing elegant parameterized SQL queries based on [ES2015 tagged template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals).
+
+Compatible with [pg](https://github.com/brianc/node-postgres), [pg-native](https://github.com/brianc/node-pg-native), [mysql](https://www.npmjs.com/package/mysql) and [mysql2](https://www.npmjs.com/package/mysql2).
 
 ## Status
 
@@ -28,31 +30,49 @@ $ npm install sql-tag
 ```js
 var sql = require('sql-tag');
 
-var out = sql`SELECT * FROM "Foo" WHERE id = ${1}`;
-// => { query: 'SELECT * FROM "Foo WHERE id = ?', values: [1] }
+var out = sql`SELECT * FROM foo WHERE id = ${'foo'}`;
+// => { query: 'SELECT * FROM foo WHERE id = $1', values: ['foo'] }
 ```
 
 The tag itself is framework agnostic. It should just require a small modification to the query generator function.
 
 **NOTE**: the `sql` tag does not provide any kind of escaping safety. It delegates that work to the underlying framework.
 
-### Integrating with [sequelize](https://github.com/sequelize/sequelize)
+### Integration with [pg](https://github.com/brianc/node-postgres)/[pg-native](https://github.com/brianc/node-pg-native)
 
-Check out the [sequelize-sql-tag](https://www.npmjs.com/sequelize-sql-tag) plugin.
+The output format is `sql-tag` is directly compatible with `pg` and `pg-native` parameterized queries.
 
-### Integrating with [pg](https://github.com/brianc/node-postgres)
+```js
+var pg = require('pg');
+var client = new pg.Client();
+var sql = require('sql-tag');
 
-Check out the [pg-sql-tag](https://www.npmjs.com/pg-sql-tag) plugin.
+client.connect(function (err) {
+  if (err) throw err;
+
+  client.query(sql`SELECT * FROM foo WHERE id = ${'foo'}`).then(console.log);
+});
+```
+
+### Integration with [mysql](https://www.npmjs.com/package/mysql)/[mysql2](https://www.npmjs.com/package/mysql2)
+
+```js
+var mysql = require('mysql');
+var connection = mysql.createConnection({ user: 'root', password: 'root' });
+var sql = require('sql-tag');
+
+connection.query(sql`SELECT * FROM foo WHERE id = ${'foo'}`, (err, rows) => console.log(err, rows));
+```
+
+### Integration with [sequelize](https://github.com/sequelize/sequelize)
+
+Sequelize requires a special format to be able to handle parameterized queries. Check out the [sequelize-sql-tag](https://www.npmjs.com/sequelize-sql-tag) plugin for it.
 
 ## Tests
 
 ```
 $ npm test
 ```
-
-## Credits
-
-Inspired by the awesome [Taras Mitran](https://github.com/qooleot) [post](http://ivc.com/blog/better-sql-strings-in-io-js-nodejs-part-2/).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
     "lint": "eslint src test",
     "prepublish": "npm run transpile",
     "test": "NODE_ENV=test mocha $npm_package_options_mocha",
-    "transpile": "rm -rf dist/* && babel src --out-dir dist/src && babel test --out-dir dist/test && cp package.json dist/",
+    "transpile": "rm -rf dist/* && babel src --out-dir dist/src && cp package.json dist/",
     "version": "npm run changelog --future-release=$npm_package_version && npm run transpile && git add -A CHANGELOG.md dist"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015-node4": "^2.1.0",
     "babel-register": "^6.11.6",
     "eslint": "^3.3.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,13 @@
 'use strict';
 
+/**
+ * Export `sql-tag`.
+ */
+
 export default function sqltag(query, ...values) {
   return {
-    query: query.join('?'),
+    sql: query.reduce((result, part) => `${result}?${part}`),
+    text: query.reduce((result, part, index) => `${result}$${index}${part}`),
     values
   };
 }

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -8,10 +8,11 @@ import sql from '../src';
 
 describe('sql-tag', () => {
   it('should support template strings with placeholders', () => {
-    const out = sql`SELECT ${'bar'} FROM "Foo" WHERE bar = ${1} AND baz IN (${['biz']})`;
+    const out = sql`SELECT * FROM "Foo" WHERE foo = ${'bar'} AND bar = ${1} AND baz IN (${['biz']})`;
 
     out.should.eql({
-      query: 'SELECT ? FROM "Foo" WHERE bar = ? AND baz IN (?)',
+      sql: 'SELECT * FROM "Foo" WHERE foo = ? AND bar = ? AND baz IN (?)',
+      text: 'SELECT * FROM "Foo" WHERE foo = $1 AND bar = $2 AND baz IN ($3)',
       values: ['bar', 1, ['biz']]
     });
   });
@@ -20,7 +21,8 @@ describe('sql-tag', () => {
     const out = sql`SELECT * FROM "Foo"`;
 
     out.should.eql({
-      query: 'SELECT * FROM "Foo"',
+      sql: 'SELECT * FROM "Foo"',
+      text: 'SELECT * FROM "Foo"',
       values: []
     });
   });


### PR DESCRIPTION
Updates the resulting format object to a _bound parameters_ approach. This format is more in keeping with the native format substitution used by most sql client libraries, ex:
- [node-postgres](https://github.com/brianc/node-postgres/wiki/Prepared-Statements#parameterized-queries)
- [sequelize](http://docs.sequelizejs.com/en/latest/docs/raw-queries/#bind-parameter)

Instead of returning:

``` js
{
  query: 'SELECT * FROM "Foo" WHERE bar = ? AND baz IN (?)',
  values: ['bar', 1, ['biz']]
}
```

We'll return:

``` js
{
  query: 'SELECT * FROM "Foo" WHERE bar = $1 AND baz IN ($2)',
  values: [1, ['biz']]
}
```

It will also greatly improve the [implementation of pg-sql-tag](https://github.com/seegno/pg-sql-tag/blob/master/index.js#L14) as well as the [implementation of sequelize-sql-tag](https://github.com/seegno/sequelize-sql-tag/blob/master/src/index.js#L22).

Additionally, it will fix a large annoyance with the _sequelize_ implementation. Consider the following sequelize raw query (using the current version of _sql-tag_):

``` js
const id = 123;

sequelize.query(sql`
  SELECT * 
  FROM users
  WHERE permissions ? 'foobar' AND id = ${id}
`);
```

This will substitute the first question mark (?) with 123, which is not what we want. Note that escaping the question mark will not work [due to the way](https://github.com/sequelize/sequelize/blob/master/lib/sql-string.js#L81) sequelize replaces these tokens. The only way to fix this is to implement named parameters or bound parameters (as this PR does).

I realize that this is a _breaking change_ for this module, so if this is accepted, the major version will need to be bumped. I'm okay with that since most users are likely using `pg-sql-tag` or `sequelize-sql-tag`, which will not introduce breaking changes (if/when their respective PRs are merged).

Fixes #1.
Depends on #2.
