### PR TITLE
Remove whitespace manipulation to avoid unintended consequences

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,28 +1,13 @@
 'use strict';
 
 /**
- * Regular expressions used for cleaning up the sql query.
- */
-
-const control = /[\t\r\n]+/gm;
-const whitespace = /\s+/gm;
-
-/**
- * Trim sql query.
- */
-
-function trim(sql) {
-  return sql.replace(control, '').replace(whitespace, ' ').trim();
-}
-
-/**
  * Export `sql-tag`.
  */
 
 export default function sqltag(query, ...values) {
   return {
-    sql: trim(query.reduce((result, part) => `${result}?${part}`)),
-    text: trim(query.reduce((result, part, index) => `${result}$${index}${part}`)),
+    sql: query.reduce((result, part) => `${result}?${part}`),
+    text: query.reduce((result, part, index) => `${result}$${index}${part}`),
     values
   };
 }

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -9,15 +9,25 @@ import sql from '../src';
 describe('sql-tag', () => {
   it('should support template literals with placeholders', () => {
     const out = sql`
-      SELECT * FROM biz
-      WHERE foo = ${'bar'}
-        AND bar = ${1}
-        AND baz IN (${['biz']})
-      `;
+        SELECT * FROM biz
+        WHERE foo = ${'bar'}
+          AND bar = ${1}
+          AND baz IN (${['biz']})
+        `;
 
     out.should.eql({
-      sql: 'SELECT * FROM biz WHERE foo = ? AND bar = ? AND baz IN (?)',
-      text: 'SELECT * FROM biz WHERE foo = $1 AND bar = $2 AND baz IN ($3)',
+      sql: `
+        SELECT * FROM biz
+        WHERE foo = ?
+          AND bar = ?
+          AND baz IN (?)
+        `,
+      text: `
+        SELECT * FROM biz
+        WHERE foo = $1
+          AND bar = $2
+          AND baz IN ($3)
+        `,
       values: ['bar', 1, ['biz']]
     });
   });


### PR DESCRIPTION
As discussed in https://github.com/seegno/sql-tag/issues/6, whitespace manipulation can have unintended consequences if not used carefully. To avoid such issues, whitespace manipulation has been completely removed.